### PR TITLE
fix(docker): autostart background service

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ A file titled ``selected_collections.json`` is created on first run and updated 
    ```
    *The app will be available at `http://localhost:5000` (or your mapped port).*
 
+   The included compose file sets `COLLEXIONS_AUTOSTART=true`, so once your
+   Plex config has been saved, the background automation service starts again
+   whenever Docker starts or restarts the container. Set it to `false` or remove
+   the variable if you prefer to start the service manually from the Dashboard.
+
 ### 🐳 Option 2: Docker Run
 
 If you prefer not to use compose, you can run the container directly:
@@ -140,6 +145,7 @@ docker run -d \
   -v /path/to/your/config:/app/config \
   -v /path/to/your/logs:/app/logs \
   -e COLLEXIONS_SECRET_KEY=your_random_secret_key_here \
+  -e COLLEXIONS_AUTOSTART=true \
   --restart unless-stopped \
   jl94x4/collexionsui:latest
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,5 @@ services:
       # IMPORTANT: Replace with a strong random key (32+ chars).
       # Generate one with: python -c "import secrets; print(secrets.token_hex(32))"
       - COLLEXIONS_SECRET_KEY=replace-this-with-a-long-random-secret-key-32chars
+      # Start the background automation service when the container starts.
+      - COLLEXIONS_AUTOSTART=true

--- a/server.py
+++ b/server.py
@@ -44,6 +44,7 @@ process = None
 
 # --- Security ---
 SECRET_KEY = os.environ.get('COLLEXIONS_SECRET_KEY', 'dev-secret-key-replace-me-in-production')
+TRUE_ENV_VALUES = {'1', 'true', 'yes', 'on'}
 
 def require_auth(f):
     @wraps(f)
@@ -126,6 +127,21 @@ def save_config(new_data, merge=True):
     except Exception as e:
         logging.error(f"Failed to save config: {e}")
         return False
+
+def env_flag_enabled(name):
+    return os.environ.get(name, '').strip().lower() in TRUE_ENV_VALUES
+
+def config_ready_for_background_process():
+    """Avoid noisy autostart failures before onboarding has saved Plex details."""
+    config = load_config()
+    missing = [key for key in ('plex_url', 'plex_token') if not config.get(key)]
+    if missing:
+        logging.info(
+            "Background service autostart skipped; missing config fields: %s",
+            ", ".join(missing)
+        )
+        return False
+    return True
 
 def load_managed_collections():
     if os.path.exists(MANAGED_COLLECTIONS_FILE):
@@ -749,13 +765,15 @@ def start_background_process():
         return False, "Script is already running (external process detected)"
     
     # Check if script exists
-    if not os.path.exists(SCRIPT_NAME):
+    script_path = os.path.join(BASE_DIR, SCRIPT_NAME)
+    if not os.path.exists(script_path):
         return False, f"Script {SCRIPT_NAME} not found."
 
     try:
         # Start the script without redirection, as it handles its own logging to the same file
         process = subprocess.Popen(
-            [sys.executable, "-u", SCRIPT_NAME]
+            [sys.executable, "-u", script_path],
+            cwd=BASE_DIR
         )
         logging.info(f"Background process started with PID: {process.pid}")
             
@@ -771,6 +789,19 @@ def run_script():
     if not success:
         return jsonify({"error": result}), 400 if "running" in result else 404 if "not found" in result else 500
     return jsonify({"success": True, "pid": result})
+
+def maybe_autostart_background_process():
+    if not env_flag_enabled('COLLEXIONS_AUTOSTART'):
+        return
+
+    if not config_ready_for_background_process():
+        return
+
+    success, result = start_background_process()
+    if success:
+        logging.info(f"Background service autostarted with PID: {result}")
+    else:
+        logging.warning(f"Background service autostart skipped: {result}")
 
 # --- Plex Helpers ---
 _plex_cache = None
@@ -1948,6 +1979,8 @@ def verify_token():
         return jsonify({'authenticated': False}), 401
 
 
+
+maybe_autostart_background_process()
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Production static file serving


### PR DESCRIPTION
## Summary
- Add `COLLEXIONS_AUTOSTART=true` support for Docker installs
- Start the background automation service on container boot once Plex config exists
- Document the env var for compose and docker run users

Fixes #7

## Validation
- `python -B -m py_compile server.py ColleXions.py`
- `docker compose config`
- `git diff --check`
